### PR TITLE
Payload gen seq experiment@0.8.1

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -19,10 +19,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: "3.10"
+        architecture: "x64"
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Extract package name and version from branch name
       id: get_pkg_info
@@ -80,10 +83,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
       with:
-        python-version: 3.6
+        python-version: "3.10"
+        architecture: "x64"
+      env:
+        AGENT_TOOLSDIRECTORY: /opt/hostedtoolcache
 
     - name: Install dependencies
       run: |

--- a/payload-gen-seq-experiment/main.nf
+++ b/payload-gen-seq-experiment/main.nf
@@ -26,7 +26,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.8.0'
+version = '0.8.1'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo-workflows/data-processing-utility-tools.payload-gen-seq-experiment'

--- a/payload-gen-seq-experiment/main.nf
+++ b/payload-gen-seq-experiment/main.nf
@@ -54,6 +54,7 @@ params.schema_url="NO_FILE5"
 params.metadata_payload_json="NO_FILE6"
 params.converted_files=["NO_FILE7"]
 params.cram_reference="NO_FILE8"
+params.recalculate_size_and_md5_files=["NO_FILE9"]
 
 process payloadGenSeqExperiment {
   container "${params.container ?: container[params.container_registry ?: default_container_registry]}:${params.container_version ?: version}"
@@ -71,6 +72,7 @@ process payloadGenSeqExperiment {
     val schema_url
     path converted_files
     path cram_reference
+    path recalculate_size_and_md5_files
 
   output:
     path "*.sequencing_experiment.payload.json", emit: payload
@@ -83,6 +85,7 @@ process payloadGenSeqExperiment {
     args_metadata_payload_json= !metadata_payload_json.name.startsWith("NO_FILE") ? "-m ${metadata_payload_json}" : ""
     args_schema_url = !schema_url.startsWith("NO_FILE")  ? "-s ${schema_url}" : ""
     args_converted_file_args = !cram_reference.startsWith("NO_FILE")  ? "-br ${cram_reference} -b ${converted_files}" : ""
+    args_recalculate_size_and_md5_files = recalculate_size_and_md5_files.empty() ? "" : "-z ${recalculate_size_and_md5_files}"
     """
     main.py \
          ${args_experiment_info_tsv} \
@@ -91,7 +94,8 @@ process payloadGenSeqExperiment {
          ${args_extra_info_tsv} \
          ${args_metadata_payload_json} \
          ${args_schema_url} \
-         ${args_converted_file_args}
+         ${args_converted_file_args} \
+         -z ${recalculate_size_and_md5_files}
     """
 }
 
@@ -106,6 +110,7 @@ workflow {
     file(params.metadata_payload_json),
     params.schema_url,
     Channel.fromPath(params.converted_files).collect(),
-    file(params.cram_reference)
+    file(params.cram_reference),
+    Channel.fromPath(params.recalculate_size_and_md5_files).collect(),
   )
 }

--- a/payload-gen-seq-experiment/main.py
+++ b/payload-gen-seq-experiment/main.py
@@ -234,7 +234,7 @@ def replace_cram_with_bam(payload,bam_from_cram,bam_from_cram_reference):
                     rg['file_r2']=bam
     return(payload)
     
-def main(metadata,url,bam_from_cram,bam_from_cram_reference,extra_info=dict()):
+def main(metadata,url,bam_from_cram,bam_from_cram_reference,recalculate_size_and_md5_files,extra_info=dict()):
     empty_str_to_null(metadata)
 
     payload = {
@@ -362,6 +362,13 @@ def main(metadata,url,bam_from_cram,bam_from_cram_reference,extra_info=dict()):
     if len(bam_from_cram)>0:
         payload=replace_cram_with_bam(payload,bam_from_cram,bam_from_cram_reference)
 
+    if len(recalculate_size_and_md5_files)>=1:
+        for recalculate in recalculate_size_and_md5_files:
+            for file in payload['files']:
+                if file['fileName']==recalculate:
+                    file['fileMd5sum']=calculate_md5(recalculate)
+                    file['fileSize']=calculate_size(recalculate)
+
     validatePayload(payload,url)
     with open("%s.sequencing_experiment.payload.json" % str(uuid.uuid4()), 'w') as f:
         f.write(json.dumps(payload, indent=2))
@@ -385,6 +392,8 @@ if __name__ == "__main__":
                         help="BAM files that have converted from CRAM")
     parser.add_argument("-br", "--bam-from-cram-reference",default=None,
                         help="Name of reference file used in cram2bam conversion")
+    parser.add_argument("-z", "--recalculate-size-and-md5-files",default=[],nargs="+",
+                        help="Supplied files here will have their md5sum and size relcalculated")                        
     args = parser.parse_args()
 
     validate_args(args)
@@ -440,4 +449,4 @@ if __name__ == "__main__":
                     extra_info[row_type][row_id][row_field]=row_val
                     
 
-        main(metadata,url,args.bam_from_cram,args.bam_from_cram_reference,extra_info)
+        main(metadata,url,args.bam_from_cram,args.bam_from_cram_reference,args.recalculate_size_and_md5_files,extra_info)

--- a/payload-gen-seq-experiment/pkg.json
+++ b/payload-gen-seq-experiment/pkg.json
@@ -1,6 +1,6 @@
 {
     "name": "payload-gen-seq-experiment",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "SONG payload generation for sequencing experiment",
     "main": "main.nf",
     "deprecated": false,

--- a/payload-gen-seq-experiment/tests/checker.nf
+++ b/payload-gen-seq-experiment/tests/checker.nf
@@ -31,7 +31,7 @@
 /* this block is auto-generated based on info from pkg.json where   */
 /* changes can be made if needed, do NOT modify this block manually */
 nextflow.enable.dsl = 2
-version = '0.8.0'
+version = '0.8.1'
 
 container = [
     'ghcr.io': 'ghcr.io/icgc-argo-workflows/data-processing-utility-tools.payload-gen-seq-experiment'

--- a/payload-gen-seq-experiment/tests/checker.nf
+++ b/payload-gen-seq-experiment/tests/checker.nf
@@ -53,6 +53,7 @@ params.schema_url = "NO_FILE5"
 params.metadata_payload_json = "NO_FILE6"
 params.converted_files=["NO_FILE7"]
 params.cram_reference="NO_FILE8"
+params.recalculate_size_and_md5_files=["NO_FILE9"]
 
 params.expected_output = ""
 
@@ -92,6 +93,7 @@ workflow checker {
     schema_url
     converted_files
     cram_reference
+    recalculate_size_and_md5_files
 
   main:
     payloadGenSeqExperiment(
@@ -102,7 +104,8 @@ workflow checker {
       metadata_payload_json,
       schema_url,
       converted_files,
-      cram_reference
+      cram_reference,
+      recalculate_size_and_md5_files
     )
 
     file_smart_diff(
@@ -122,6 +125,7 @@ workflow {
     file(params.metadata_payload_json),
     params.schema_url,
     Channel.fromPath(params.converted_files).collect(),
-    file(params.cram_reference)
+    file(params.cram_reference),
+    Channel.fromPath(params.recalculate_size_and_md5_files).collect()
   )
 }

--- a/payload-gen-seq-experiment/tests/input/1c1e4354-b224-4d69-afcb-5be749a183d5.sequencing_experiment.payload.json
+++ b/payload-gen-seq-experiment/tests/input/1c1e4354-b224-4d69-afcb-5be749a183d5.sequencing_experiment.payload.json
@@ -1,0 +1,86 @@
+{
+  "analysisType": {
+    "name": "sequencing_experiment"
+  },
+  "studyId": "TEST-PRO",
+  "experiment": {
+    "submitter_sequencing_experiment_id": "TEST_EXP",
+    "sequencing_center": "EXT",
+    "platform": "ILLUMINA",
+    "platform_model": "HiSeq 2000",
+    "experimental_strategy": "WGS",
+    "sequencing_date": "2014-12-12"
+  },
+  "read_group_count": 3,
+  "read_groups": [
+    {
+      "submitter_read_group_id": "C0HVY.2",
+      "read_group_id_in_bam": null,
+      "platform_unit": "74_8a",
+      "is_paired_end": true,
+      "file_r1": "test_rg_3.bam",
+      "file_r2": "test_rg_3.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    },
+    {
+      "submitter_read_group_id": "D0RE2.1",
+      "read_group_id_in_bam": null,
+      "platform_unit": "74_8b",
+      "is_paired_end": true,
+      "file_r1": "test_rg_3.bam",
+      "file_r2": "test_rg_3.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    },
+    {
+      "submitter_read_group_id": "D0RH0.2",
+      "read_group_id_in_bam": null,
+      "platform_unit": "74_8c",
+      "is_paired_end": true,
+      "file_r1": "test_rg_3.bam",
+      "file_r2": "test_rg_3.bam",
+      "read_length_r1": 150,
+      "read_length_r2": 150,
+      "insert_size": 298,
+      "sample_barcode": null,
+      "library_name": "Pond-147580"
+    }
+  ],
+  "samples": [
+    {
+      "submitterSampleId": "HCC1143_BAM_INPUT",
+      "matchedNormalSubmitterSampleId": null,
+      "sampleType": "Total DNA",
+      "specimen": {
+        "submitterSpecimenId": "HCC1143_BAM_INPUT",
+        "tumourNormalDesignation": "Normal",
+        "specimenTissueSource": "Blood derived",
+        "specimenType": "Cell line - derived from normal"
+      },
+      "donor": {
+        "submitterDonorId": "HCC1143",
+        "gender": "Female"
+      }
+    }
+  ],
+  "files": [
+    {
+      "fileName": "example1.bam",
+      "fileSize": 10,
+      "fileMd5sum": "e2bb33a7b2c6a45933a994e3e2747458",
+      "fileType": "BAM",
+      "fileAccess": "controlled",
+      "dataType": "Submitted Reads",
+      "info": {
+        "data_category": "Sequencing Reads"
+      }
+    }
+  ]
+}

--- a/payload-gen-seq-experiment/tests/input/file.replace.tsv
+++ b/payload-gen-seq-experiment/tests/input/file.replace.tsv
@@ -1,0 +1,2 @@
+type	name	format	size	md5sum	path
+file	example1.bam	BAM	1	AAAA	input/example1.bam

--- a/payload-gen-seq-experiment/tests/test-job-bam.replace.nf.json
+++ b/payload-gen-seq-experiment/tests/test-job-bam.replace.nf.json
@@ -1,0 +1,8 @@
+{
+  "experiment_info_tsv": "input/experiment.v2.tsv",
+  "read_group_info_tsv": "input/read_group.v2.tsv",
+  "file_info_tsv": "input/file.replace.tsv",
+  "expected_output": "input/1c1e4354-b224-4d69-afcb-5be749a183d5.sequencing_experiment.payload.json",
+  "recalculate_size_and_md5_files": ["input/example1.bam"],
+  "publish_dir": "outdir"
+}


### PR DESCRIPTION
Test case:
```
payload-gen-seq-experiment/tests/test-job-bam.replace.nf.json
```
`file_info_tsv` contains schema breaking `md5sum` and `fileSize`. On the fly recalculation replaces with correct values.